### PR TITLE
fix automated tasks

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          persist-credentials: false
+          persist-credentials: true # Required for pushing
           fetch-depth: 0 # Required to see all tags, not just the latest commit
 
       - name: Configure Git

--- a/.github/workflows/sync-staging.yaml
+++ b/.github/workflows/sync-staging.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.ACCESS_TOKEN }}
-          persist-credentials: false
+          persist-credentials: true # Required for pushing
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
If we are pushing to git, we need the token, therefore we must persist credentials.